### PR TITLE
Extract git aliases to subcommands.

### DIFF
--- a/aliases
+++ b/aliases
@@ -21,4 +21,4 @@ alias airport="/System/Library/PrivateFrameworks/Apple80211.framework/Versions/C
 
 alias ack="ag"
 
-alias cp-branch="git symbolic-ref --short HEAD | tr -d '\n' | pbcopy"
+alias cp-branch="git current-branch | tr -d '\n' | pbcopy"

--- a/bin/git-attach
+++ b/bin/git-attach
@@ -2,5 +2,5 @@
 
 set -e
 
-current=`git current-branch`
-git branch --set-upstream-to=origin/$current
+branch=`git current-branch`
+git branch --set-upstream-to=origin/$branch

--- a/bin/git-attach
+++ b/bin/git-attach
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+current=`git current-branch`
+git branch --set-upstream-to=origin/$current

--- a/bin/git-current-branch
+++ b/bin/git-current-branch
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+git rev-parse --abbrev-ref HEAD

--- a/bin/git-delete-branch
+++ b/bin/git-delete-branch
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+git branch -D $1
+git push origin :$1
+git remote prune origin

--- a/bin/git-merge-branch
+++ b/bin/git-merge-branch
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+git checkout master
+git merge @{-1}

--- a/bin/git-merge-master
+++ b/bin/git-merge-master
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+git fetch origin
+git merge origin/master

--- a/bin/git-merge-upstream
+++ b/bin/git-merge-upstream
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+git fetch upstream
+git merge upstream/master

--- a/bin/git-pp
+++ b/bin/git-pp
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+git pull
+git push

--- a/bin/git-rename-branch
+++ b/bin/git-rename-branch
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+old-branch=`git current-branch`
+git branch -m "$old-branch" "$1"
+git push origin --set-upstream "$1"
+git push origin --delete "$old-branch"

--- a/bin/git-safe-bin
+++ b/bin/git-safe-bin
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -e
+
+mkdir -p .git/safe

--- a/bin/git-squash-branch
+++ b/bin/git-squash-branch
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+git checkout master
+git merge --squash @{-1}
+git commit

--- a/bin/git-up
+++ b/bin/git-up
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+git fetch origin
+git rebase origin/master

--- a/gitconfig
+++ b/gitconfig
@@ -1,13 +1,6 @@
 [init]
   templatedir = ~/.git_template
 [alias]
-  delete-branch = !sh -c 'git branch -D $1 && git push origin :$1 && git remote prune origin' -
-  squash-branch = !git checkout master && git merge --squash @{-1} && git commit
-  merge-branch = !git checkout master && git merge @{-1}
-  merge-master = !git fetch origin && git merge origin/master
-  pp = !git pull && git push
-  up = !git fetch origin && git rebase origin/master
-  attach = !git branch --set-upstream-to=origin/`git symbolic-ref --short HEAD`
 [branch]
   autosetuprebase = always
 [include]

--- a/gitconfig
+++ b/gitconfig
@@ -1,6 +1,7 @@
 [init]
   templatedir = ~/.git_template
 [alias]
+  branches = for-each-ref --sort=-committerdate --format=\"%(color:blue)%(authordate:relative)\t%(color:red)%(authorname)\t%(color:white)%(color:bold)%(refname:short)\" refs/remotes
 [branch]
   autosetuprebase = always
 [include]

--- a/zsh/configs/post/path.zsh
+++ b/zsh/configs/post/path.zsh
@@ -1,5 +1,3 @@
-PATH="$HOME/.bin:/usr/local/sbin:$PATH"
-
 # load rbenv if available
 if which rbenv &>/dev/null ; then
   eval "$(rbenv init -)"
@@ -7,6 +5,8 @@ fi
 
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
+PATH="$HOME/.bin:/usr/local/sbin:$PATH"
 
 # mkdir .git/safe in the root of repositories you trust
 PATH=".git/safe/../../bin:$PATH"


### PR DESCRIPTION
Some git aliases can get a little crazy.  They're can be much more readable if we extract them to subcommands in `~/.bin`